### PR TITLE
fix: correct author email

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "authors": [
         {
             "name": "Christoph Daum",
-            "email": "info@apermo.de"
+            "email": "me@christoph-daum.de"
         }
     ],
     "require": {


### PR DESCRIPTION
Replace `info@apermo.de` with `me@christoph-daum.de` in composer.json authors field.