### PR TITLE
v0.8.0: rename Plugin class to Main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-20
+
+### Changed
+
+- **BREAKING:** Plugin mode main class renamed from `Plugin` to `Main`
+  (`src/Plugin.php` → `src/Main.php`). Resolves the confusing collision
+  with the root `plugin.php` bootstrap file. Derived projects extending
+  or referencing the `Plugin` class must rename usages to `Main` (or
+  keep their own class name and update the `plugin.php` bootstrap call
+  accordingly). Template files updated: `plugin.php`, `setup.sh`,
+  `tests/Unit/MainTest.php`, `tests/Integration/ExampleIntegrationTest.php`,
+  `CLAUDE.md`. See [#39](https://github.com/apermo/template-wordpress/issues/39).
+
 ## [0.7.0] - 2026-04-20
 
 ### Added
@@ -134,6 +147,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Workflow callers missing permissions (caused startup_failure)
 
+[0.8.0]: https://github.com/apermo/template-wordpress/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/apermo/template-wordpress/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/apermo/template-wordpress/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/apermo/template-wordpress/compare/v0.5.0...v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ GitHub template repository for bootstrapping WordPress plugins and themes. Ships
 
 Both modes coexist in the repo. The `setup.sh` script (see #10) removes the irrelevant set after the developer picks a mode.
 
-**Plugin mode files:** `plugin.php` (main file), `src/Plugin.php`, `uninstall.php`, `.github/workflows/plugin-check.yml` (dropped if WP.org publishing is declined)
+**Plugin mode files:** `plugin.php` (main file), `src/Main.php`, `uninstall.php`, `.github/workflows/plugin-check.yml` (dropped if WP.org publishing is declined)
 **Theme mode files:** `style.css`, `functions.php`, `src/Theme.php`, `templates/`, `parts/`, `assets/`, `.github/workflows/lhci.yml`, `.lighthouserc.js`, `.wp-env.json`
 **Shared:** `src/` (PSR-4 root), `tests/`, `e2e/` (incl. `helpers/a11y.js` + `a11y.spec.js`), `composer.json`, CI config, DDEV config
 

--- a/plugin.php
+++ b/plugin.php
@@ -40,4 +40,4 @@ if ( ! \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-Plugin::init( __FILE__ );
+Main::init( __FILE__ );

--- a/setup.sh
+++ b/setup.sh
@@ -131,8 +131,8 @@ if [ "$PROJECT_MODE" = "plugin" ]; then
 else
     # Remove plugin files
     rm -f plugin.php uninstall.php
-    rm -f src/Plugin.php
-    rm -f tests/Unit/PluginTest.php
+    rm -f src/Main.php
+    rm -f tests/Unit/MainTest.php
 
     # Remove plugin-only Plugin Check workflow
     rm -f .github/workflows/plugin-check.yml

--- a/src/Main.php
+++ b/src/Main.php
@@ -7,7 +7,7 @@ namespace Plugin_Name;
 /**
  * Bootstraps the plugin.
  */
-class Plugin {
+class Main {
 
 	public const VERSION = '0.1.0';
 

--- a/tests/Integration/ExampleIntegrationTest.php
+++ b/tests/Integration/ExampleIntegrationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Plugin_Name\Tests\Integration;
 
-use Plugin_Name\Plugin;
+use Plugin_Name\Main;
 use WP_UnitTestCase;
 
 /**
@@ -31,7 +31,7 @@ class ExampleIntegrationTest extends WP_UnitTestCase {
 
 		if ( \file_exists( $plugin_file ) ) {
 			$this->assertNotEmpty(
-				Plugin::VERSION,
+				Main::VERSION,
 				'Plugin version should be set.',
 			);
 		} else {

--- a/tests/Unit/MainTest.php
+++ b/tests/Unit/MainTest.php
@@ -7,12 +7,12 @@ namespace Plugin_Name\Tests\Unit;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
-use Plugin_Name\Plugin;
+use Plugin_Name\Main;
 
 /**
- * Tests for the Plugin class.
+ * Tests for the Main class.
  */
-class PluginTest extends TestCase {
+class MainTest extends TestCase {
 
 	/**
 	 * Sets up Brain Monkey.
@@ -44,17 +44,17 @@ class PluginTest extends TestCase {
 
 		Functions\expect( 'register_activation_hook' )
 			->once()
-			->with( $file, [ Plugin::class, 'activate' ] );
+			->with( $file, [ Main::class, 'activate' ] );
 
 		Functions\expect( 'register_deactivation_hook' )
 			->once()
-			->with( $file, [ Plugin::class, 'deactivate' ] );
+			->with( $file, [ Main::class, 'deactivate' ] );
 
 		Functions\expect( 'add_action' )
 			->once()
-			->with( 'plugins_loaded', [ Plugin::class, 'boot' ] );
+			->with( 'plugins_loaded', [ Main::class, 'boot' ] );
 
-		Plugin::init( $file );
+		Main::init( $file );
 	}
 
 	/**
@@ -73,9 +73,9 @@ class PluginTest extends TestCase {
 			],
 		);
 
-		Plugin::init( $file );
+		Main::init( $file );
 
-		$this->assertSame( $file, Plugin::file() );
+		$this->assertSame( $file, Main::file() );
 	}
 
 	/**
@@ -84,7 +84,7 @@ class PluginTest extends TestCase {
 	 * @return void
 	 */
 	public function test_activate(): void {
-		Plugin::activate();
+		Main::activate();
 		$this->assertTrue( true );
 	}
 
@@ -94,7 +94,7 @@ class PluginTest extends TestCase {
 	 * @return void
 	 */
 	public function test_deactivate(): void {
-		Plugin::deactivate();
+		Main::deactivate();
 		$this->assertTrue( true );
 	}
 
@@ -104,7 +104,7 @@ class PluginTest extends TestCase {
 	 * @return void
 	 */
 	public function test_boot(): void {
-		Plugin::boot();
+		Main::boot();
 		$this->assertTrue( true );
 	}
 }


### PR DESCRIPTION
## Summary

- **BREAKING:** Renames the plugin-mode main class from `Plugin` to `Main` (`src/Plugin.php` → `src/Main.php`) to remove the confusing collision with the root `plugin.php` bootstrap file.
- Updates all references: `plugin.php` bootstrap call, unit + integration tests, `setup.sh` mode cleanup, `CLAUDE.md`.
- Renames `tests/Unit/PluginTest.php` → `tests/Unit/MainTest.php` (class `PluginTest` → `MainTest`).

Closes #39.

## Migration for derived projects

Projects synced from the template that extended or referenced the `Plugin` class must either:

- Rename their usages `Plugin` → `Main`, **or**
- Keep their existing class name and update the `plugin.php` bootstrap to call their own class instead of `Main::init()`.

The template-sync merge will show the rename as a delta.

## Test plan

- [x] `composer cs` passes
- [x] `composer analyse` passes
- [x] `composer test:unit` passes (5/5)
- [ ] CI green on PR
- [ ] Verify template-sync merge from a downstream project applies cleanly