### PR TITLE
feat: opt-in confirm-deactivate example + bump coding-standards to ^3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Opt-in confirm-deactivate example under `src/Admin/DeactivationFlow.php`
+  (plugin mode). Routes the plugin's "Deactivate" link through a
+  confirmation screen that gates destructive cleanup behind capability,
+  nonce, and an in-form checkbox in the same request. The setup script
+  prompts whether to include it; declined removes the files.
+
 ### Changed
 
 - **BREAKING:** Bump `apermo/apermo-coding-standards` to `^3.0`. Derived

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-05-02
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING:** Bump `apermo/apermo-coding-standards` to `^3.0`. Derived
+  projects must replace any short echo tags `<?= … ?>` with
+  `<?php echo esc_html( … ); ?>` and ensure every `wp_redirect()` /
+  `wp_safe_redirect()` call is followed by `exit;`.
+
 ## [0.8.0] - 2026-04-20
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,16 +14,18 @@ GitHub template repository for bootstrapping WordPress plugins and themes. Ships
 
 Both modes coexist in the repo. The `setup.sh` script (see #10) removes the irrelevant set after the developer picks a mode.
 
-**Plugin mode files:** `plugin.php` (main file), `src/Main.php`, `uninstall.php`, `.github/workflows/plugin-check.yml` (dropped if WP.org publishing is declined)
+**Plugin mode files:** `plugin.php` (main file), `src/Main.php`, `uninstall.php`, `.github/workflows/plugin-check.yml` (dropped if WP.org publishing is declined), `src/Admin/DeactivationFlow.php` + `src/Admin/views/confirm-deactivate.php` (optional, dropped if declined in setup)
 **Theme mode files:** `style.css`, `functions.php`, `src/Theme.php`, `templates/`, `parts/`, `assets/`, `.github/workflows/lhci.yml`, `.lighthouserc.js`, `.wp-env.json`
 **Shared:** `src/` (PSR-4 root), `tests/`, `e2e/` (incl. `helpers/a11y.js` + `a11y.spec.js`), `composer.json`, CI config, DDEV config
 
 ### Key conventions
 
 - PSR-4 autoloading under `src/`
-- Coding standards: `apermo/apermo-coding-standards` ^2.9 (PHPCS). Docblock
+- Coding standards: `apermo/apermo-coding-standards` ^3.0 (PHPCS). Docblock
   summaries must be third-person singular (`Initializes the plugin`, not
-  `Initialize the plugin`) — enforced by the 2.8+ summary sniff.
+  `Initialize the plugin`) — enforced by the 2.8+ summary sniff. The 3.0
+  release forbids short echo tags `<?= … ?>` and requires `exit;` after
+  every `wp_redirect()` / `wp_safe_redirect()` call.
 - Static analysis: `apermo/phpstan-wordpress-rules` + `szepeviktor/phpstan-wordpress`
 - Testing: PHPUnit + Brain Monkey + Yoast PHPUnit Polyfills
 - Test suites: `tests/Unit/` and `tests/Integration/`

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=8.1"
     },
     "require-dev": {
-        "apermo/apermo-coding-standards": "^2.9",
+        "apermo/apermo-coding-standards": "^3.0",
         "apermo/phpstan-wordpress-rules": "^0.2",
         "brain/monkey": "^2.6",
         "phpstan/extension-installer": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9af462c30698ed3c5451ab3c836145c1",
+    "content-hash": "88943106b336ee7cdd3f0d1cca496109",
     "packages": [],
     "packages-dev": [
         {
@@ -57,16 +57,16 @@
         },
         {
             "name": "apermo/apermo-coding-standards",
-            "version": "v2.9.0",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/apermo/apermo-coding-standards.git",
-                "reference": "36a507e08ca248c2e3074b38b7cc08910cfe1321"
+                "reference": "61f264eb411bb1a4ca581ca6c60740426596a85e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/36a507e08ca248c2e3074b38b7cc08910cfe1321",
-                "reference": "36a507e08ca248c2e3074b38b7cc08910cfe1321",
+                "url": "https://api.github.com/repos/apermo/apermo-coding-standards/zipball/61f264eb411bb1a4ca581ca6c60740426596a85e",
+                "reference": "61f264eb411bb1a4ca581ca6c60740426596a85e",
                 "shasum": ""
             },
             "require": {
@@ -112,7 +112,7 @@
                 "issues": "https://github.com/apermo/apermo-coding-standards/issues",
                 "source": "https://github.com/apermo/apermo-coding-standards"
             },
-            "time": "2026-04-20T07:27:42+00:00"
+            "time": "2026-05-02T12:32:03+00:00"
         },
         {
             "name": "apermo/phpstan-wordpress-rules",

--- a/setup.sh
+++ b/setup.sh
@@ -86,89 +86,12 @@ echo ""
 
 # --- Opt-out: confirm-deactivate example ---
 
-# Run before placeholder replacement so heredoc content uses the original
-# tokens (Plugin_Name, plugin-name) and gets rewritten by the normal pass.
 if [ "$PROJECT_MODE" = "plugin" ] && [[ ! "$INCLUDE_DEACTIVATION_FLOW" =~ ^[Yy]$ ]]; then
     info "Removing opt-in confirm-deactivate example..."
-    rm -rf src/Admin/
-    rm -rf tests/Unit/Admin/
-
-    cat > src/Main.php <<'MAIN_EOF'
-<?php
-
-declare(strict_types=1);
-
-namespace Plugin_Name;
-
-/**
- * Bootstraps the plugin.
- */
-class Main {
-
-	public const VERSION = '0.1.0';
-
-	/**
-	 * Holds the main plugin file path.
-	 *
-	 * @var string
-	 */
-	private static string $file = '';
-
-	/**
-	 * Initializes the plugin.
-	 *
-	 * @param string $file Main plugin file path.
-	 *
-	 * @return void
-	 */
-	public static function init( string $file ): void {
-		self::$file = $file;
-
-		register_activation_hook( $file, [ self::class, 'activate' ] );
-		register_deactivation_hook( $file, [ self::class, 'deactivate' ] );
-		add_action( 'plugins_loaded', [ self::class, 'boot' ] );
-	}
-
-	/**
-	 * Returns the main plugin file path.
-	 *
-	 * @return string
-	 */
-	public static function file(): string {
-		return self::$file;
-	}
-
-	/**
-	 * Activates the plugin.
-	 *
-	 * @return void
-	 */
-	public static function activate(): void {
-		// Activation logic.
-	}
-
-	/**
-	 * Deactivates the plugin.
-	 *
-	 * @return void
-	 */
-	public static function deactivate(): void {
-		// Deactivation logic.
-	}
-
-	/**
-	 * Boots the plugin after all plugins are loaded.
-	 *
-	 * @return void
-	 */
-	public static function boot(): void {
-		// Initialize plugin functionality.
-	}
-}
-MAIN_EOF
-
-    # Delete the is_admin stub and the blank line that follows it.
-    sedi "/Functions\\\\stubs( \\[ 'is_admin' => false \\] );/{N;d;}" tests/Unit/MainTest.php
+    rm -rf src/Admin/ tests/Unit/Admin/
+    warn "Now delete the lines marked '// OPT-IN: confirm-deactivate' in:"
+    warn "  - src/Main.php"
+    warn "  - tests/Unit/MainTest.php"
 fi
 
 # --- Replace placeholders ---

--- a/setup.sh
+++ b/setup.sh
@@ -49,6 +49,12 @@ done
 
 # WordPress.org publishing
 read -rp "Publish to WordPress.org? (y/N): " WPORG_PUBLISH
+
+# Optional confirm-deactivate example (plugin mode only)
+INCLUDE_DEACTIVATION_FLOW="n"
+if [ "$PROJECT_MODE" = "plugin" ]; then
+    read -rp "Include opt-in confirm-deactivate example? (y/N): " INCLUDE_DEACTIVATION_FLOW
+fi
 echo ""
 
 # --- Derive placeholder values ---
@@ -77,6 +83,93 @@ echo "  Namespace:   ${NAMESPACE}"
 echo "  Composer:    ${COMPOSER_NAME}"
 echo "  Mode:        ${PROJECT_MODE}"
 echo ""
+
+# --- Opt-out: confirm-deactivate example ---
+
+# Run before placeholder replacement so heredoc content uses the original
+# tokens (Plugin_Name, plugin-name) and gets rewritten by the normal pass.
+if [ "$PROJECT_MODE" = "plugin" ] && [[ ! "$INCLUDE_DEACTIVATION_FLOW" =~ ^[Yy]$ ]]; then
+    info "Removing opt-in confirm-deactivate example..."
+    rm -rf src/Admin/
+    rm -rf tests/Unit/Admin/
+
+    cat > src/Main.php <<'MAIN_EOF'
+<?php
+
+declare(strict_types=1);
+
+namespace Plugin_Name;
+
+/**
+ * Bootstraps the plugin.
+ */
+class Main {
+
+	public const VERSION = '0.1.0';
+
+	/**
+	 * Holds the main plugin file path.
+	 *
+	 * @var string
+	 */
+	private static string $file = '';
+
+	/**
+	 * Initializes the plugin.
+	 *
+	 * @param string $file Main plugin file path.
+	 *
+	 * @return void
+	 */
+	public static function init( string $file ): void {
+		self::$file = $file;
+
+		register_activation_hook( $file, [ self::class, 'activate' ] );
+		register_deactivation_hook( $file, [ self::class, 'deactivate' ] );
+		add_action( 'plugins_loaded', [ self::class, 'boot' ] );
+	}
+
+	/**
+	 * Returns the main plugin file path.
+	 *
+	 * @return string
+	 */
+	public static function file(): string {
+		return self::$file;
+	}
+
+	/**
+	 * Activates the plugin.
+	 *
+	 * @return void
+	 */
+	public static function activate(): void {
+		// Activation logic.
+	}
+
+	/**
+	 * Deactivates the plugin.
+	 *
+	 * @return void
+	 */
+	public static function deactivate(): void {
+		// Deactivation logic.
+	}
+
+	/**
+	 * Boots the plugin after all plugins are loaded.
+	 *
+	 * @return void
+	 */
+	public static function boot(): void {
+		// Initialize plugin functionality.
+	}
+}
+MAIN_EOF
+
+    # Delete the is_admin stub and the blank line that follows it.
+    sedi "/Functions\\\\stubs( \\[ 'is_admin' => false \\] );/{N;d;}" tests/Unit/MainTest.php
+fi
 
 # --- Replace placeholders ---
 
@@ -128,11 +221,14 @@ if [ "$PROJECT_MODE" = "plugin" ]; then
 
     # Clean phpstan.neon.dist
     sedi '/- functions.php/d' phpstan.neon.dist
+
 else
     # Remove plugin files
     rm -f plugin.php uninstall.php
     rm -f src/Main.php
     rm -f tests/Unit/MainTest.php
+    rm -rf src/Admin/
+    rm -rf tests/Unit/Admin/
 
     # Remove plugin-only Plugin Check workflow
     rm -f .github/workflows/plugin-check.yml

--- a/src/Admin/DeactivationFlow.php
+++ b/src/Admin/DeactivationFlow.php
@@ -96,9 +96,10 @@ class DeactivationFlow {
 		$basename = plugin_basename( Main::file() );
 
 		// phpcs:disable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable -- Used by the included view.
-		$deactivate   = $this->safe_deactivate_url( $basename );
-		$delete_url   = admin_url( 'admin.php' );
-		$delete_nonce = wp_create_nonce( self::DELETE_ACTION );
+		$deactivate    = $this->safe_deactivate_url( $basename );
+		$delete_url    = admin_url( 'admin.php' );
+		$delete_action = self::DELETE_ACTION;
+		$delete_nonce  = wp_create_nonce( self::DELETE_ACTION );
 		// phpcs:enable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 
 		require __DIR__ . '/views/confirm-deactivate.php';

--- a/src/Admin/DeactivationFlow.php
+++ b/src/Admin/DeactivationFlow.php
@@ -77,7 +77,7 @@ class DeactivationFlow {
 			'',
 			__( 'Deactivate plugin-name', 'plugin-name' ),
 			__( 'Deactivate plugin-name', 'plugin-name' ),
-			'activate_plugins',
+			$this->current_capability(),
 			self::CONFIRM_PAGE,
 			[ $this, 'render_confirm_page' ],
 		);
@@ -89,7 +89,7 @@ class DeactivationFlow {
 	 * @return void
 	 */
 	public function render_confirm_page(): void {
-		if ( ! current_user_can( 'activate_plugins' ) ) {
+		if ( ! current_user_can( $this->current_capability() ) ) {
 			wp_die( esc_html__( 'You do not have permission to deactivate this plugin.', 'plugin-name' ), 403 );
 		}
 
@@ -97,12 +97,26 @@ class DeactivationFlow {
 
 		// phpcs:disable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable -- Used by the included view.
 		$deactivate    = $this->safe_deactivate_url( $basename );
-		$delete_url    = admin_url( 'admin.php' );
+		$delete_url    = is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' );
 		$delete_action = self::DELETE_ACTION;
 		$delete_nonce  = wp_create_nonce( self::DELETE_ACTION );
 		// phpcs:enable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 
 		require __DIR__ . '/views/confirm-deactivate.php';
+	}
+
+	/**
+	 * Returns the capability required for both viewing the confirmation screen
+	 * and submitting the destructive form. Mirrors WordPress's plugin-row
+	 * deactivation gate: network-active plugins need `manage_network_plugins`,
+	 * everything else uses `activate_plugins`.
+	 *
+	 * @return string
+	 */
+	private function current_capability(): string {
+		return is_plugin_active_for_network( plugin_basename( Main::file() ) )
+			? 'manage_network_plugins'
+			: 'activate_plugins';
 	}
 
 	/**
@@ -137,23 +151,23 @@ class DeactivationFlow {
 			wp_die( esc_html__( 'You must be logged in.', 'plugin-name' ), 403 );
 		}
 
-		$basename   = plugin_basename( Main::file() );
-		$capability = is_plugin_active_for_network( $basename ) ? 'manage_network_plugins' : 'activate_plugins';
-
-		if ( ! current_user_can( $capability ) ) {
+		if ( ! current_user_can( $this->current_capability() ) ) {
 			wp_die( esc_html__( 'You do not have permission to deactivate this plugin.', 'plugin-name' ), 403 );
 		}
 
 		check_admin_referer( self::DELETE_ACTION );
 
-		$confirm = isset( $_POST['confirm'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['confirm'] ) ) : '';
+		$confirm = isset( $_POST['confirm'] ) && \is_scalar( $_POST['confirm'] )
+			? sanitize_text_field( wp_unslash( (string) $_POST['confirm'] ) )
+			: '';
 
-		if ( $confirm === '' ) {
+		if ( $confirm !== '1' ) {
 			wp_die( esc_html__( 'Confirmation checkbox was not checked.', 'plugin-name' ), 400 );
 		}
 
-		$this->run_cleanup();
+		$this->cleanup_plugin_data();
 
+		$basename = plugin_basename( Main::file() );
 		deactivate_plugins( $basename, false, is_network_admin() );
 
 		$redirect = add_query_arg(
@@ -169,25 +183,14 @@ class DeactivationFlow {
 	}
 
 	/**
-	 * Switches to the main site on multisite, runs cleanup, then restores
-	 * context. Single-site installs run cleanup directly.
-	 *
-	 * @return void
-	 */
-	private function run_cleanup(): void {
-		if ( is_multisite() ) {
-			switch_to_blog( get_main_site_id() );
-			$this->cleanup_plugin_data();
-			restore_current_blog();
-			return;
-		}
-
-		$this->cleanup_plugin_data();
-	}
-
-	/**
 	 * Removes all plugin-owned data. Override or extend in derived projects
 	 * to drop custom tables, options, transients, and metadata.
+	 *
+	 * Multisite caveat: when the plugin is **network-activated**, settings
+	 * typically live in network meta (`*_site_option`), not in any single
+	 * site's options table. When the plugin is **per-site activated**, each
+	 * site has its own copy in its options table — wiping all of them
+	 * requires iterating sites explicitly.
 	 *
 	 * Example extensions:
 	 * - $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}plugin_name_…" );
@@ -201,6 +204,24 @@ class DeactivationFlow {
 	 * @return void
 	 */
 	protected function cleanup_plugin_data(): void {
+		if ( is_multisite() && is_plugin_active_for_network( plugin_basename( Main::file() ) ) ) {
+			// Network-activated: site options live in network meta;
+			// `delete_site_option()` works regardless of the current blog.
+			delete_site_option( 'plugin_name_settings' );
+
+			/*
+			 * To wipe per-site data on every site, iterate explicitly:
+			 *
+			 *     foreach ( get_sites( [ 'fields' => 'ids' ] ) as $site_id ) {
+			 *         switch_to_blog( $site_id );
+			 *         delete_option( 'plugin_name_per_site_settings' );
+			 *         restore_current_blog();
+			 *     }
+			 */
+			return;
+		}
+
+		// Per-site activation or single-site install: delete on the current site.
 		delete_option( 'plugin_name_settings' );
 	}
 }

--- a/src/Admin/DeactivationFlow.php
+++ b/src/Admin/DeactivationFlow.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plugin_Name\Admin;
+
+use Plugin_Name\Main;
+
+/**
+ * Routes the plugin's "Deactivate" link through a confirmation screen so that
+ * destructive cleanup of plugin data only runs after the user explicitly opts
+ * in. The destructive path is gated by capability, nonce, and an in-form
+ * checkbox in the same request — no persistent "allow delete" option.
+ *
+ * Derived projects fill in {@see self::cleanup_plugin_data()} with whatever
+ * tables, options, transients, and metadata they own.
+ */
+class DeactivationFlow {
+
+	/**
+	 * Hidden admin page slug used for the confirmation screen.
+	 */
+	public const CONFIRM_PAGE = 'plugin-name-deactivate';
+
+	/**
+	 * admin-post.php / admin_action_* handler key for the destructive submission.
+	 */
+	public const DELETE_ACTION = 'plugin_name_deactivate_and_delete';
+
+	/**
+	 * Wires the deactivation flow into WordPress.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		$basename = plugin_basename( Main::file() );
+
+		add_filter( "plugin_action_links_{$basename}", [ $this, 'rewrite_deactivate_link' ] );
+		add_filter( "network_admin_plugin_action_links_{$basename}", [ $this, 'rewrite_deactivate_link' ] );
+		add_action( 'admin_menu', [ $this, 'register_hidden_page' ] );
+		add_action( 'network_admin_menu', [ $this, 'register_hidden_page' ] );
+		add_action( 'admin_action_' . self::DELETE_ACTION, [ $this, 'handle_destructive' ] );
+	}
+
+	/**
+	 * Replaces the default "Deactivate" plugin row link with a link to the
+	 * confirmation screen.
+	 *
+	 * @param array<string, string> $actions Plugin action links.
+	 *
+	 * @return array<string, string>
+	 */
+	public function rewrite_deactivate_link( array $actions ): array {
+		if ( ! isset( $actions['deactivate'] ) ) {
+			return $actions;
+		}
+
+		$base_url = is_network_admin() ? network_admin_url( 'admin.php' ) : admin_url( 'admin.php' );
+		$url      = add_query_arg( [ 'page' => self::CONFIRM_PAGE ], $base_url );
+
+		$actions['deactivate'] = \sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( $url ),
+			esc_html__( 'Deactivate', 'plugin-name' ),
+		);
+
+		return $actions;
+	}
+
+	/**
+	 * Registers the confirmation screen as a hidden submenu page.
+	 *
+	 * @return void
+	 */
+	public function register_hidden_page(): void {
+		add_submenu_page(
+			'',
+			__( 'Deactivate plugin-name', 'plugin-name' ),
+			__( 'Deactivate plugin-name', 'plugin-name' ),
+			'activate_plugins',
+			self::CONFIRM_PAGE,
+			[ $this, 'render_confirm_page' ],
+		);
+	}
+
+	/**
+	 * Renders the confirmation screen.
+	 *
+	 * @return void
+	 */
+	public function render_confirm_page(): void {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			wp_die( esc_html__( 'You do not have permission to deactivate this plugin.', 'plugin-name' ), 403 );
+		}
+
+		$basename = plugin_basename( Main::file() );
+
+		// phpcs:disable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable -- Used by the included view.
+		$deactivate   = $this->safe_deactivate_url( $basename );
+		$delete_url   = admin_url( 'admin.php' );
+		$delete_nonce = wp_create_nonce( self::DELETE_ACTION );
+		// phpcs:enable SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+
+		require __DIR__ . '/views/confirm-deactivate.php';
+	}
+
+	/**
+	 * Builds the standard WordPress deactivate URL with nonce, used by the
+	 * "keep data" path on the confirmation screen.
+	 *
+	 * @param string $basename Plugin basename, e.g. plugin-name/plugin.php.
+	 *
+	 * @return string
+	 */
+	private function safe_deactivate_url( string $basename ): string {
+		$base_url = is_network_admin() ? network_admin_url( 'plugins.php' ) : admin_url( 'plugins.php' );
+		$url      = add_query_arg(
+			[
+				'action' => 'deactivate',
+				'plugin' => $basename,
+			],
+			$base_url,
+		);
+
+		return wp_nonce_url( $url, 'deactivate-plugin_' . $basename );
+	}
+
+	/**
+	 * Handles the destructive submission: verifies all gates, runs cleanup,
+	 * deactivates the plugin, then redirects back to the plugins list.
+	 *
+	 * @return void
+	 */
+	public function handle_destructive(): void {
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html__( 'You must be logged in.', 'plugin-name' ), 403 );
+		}
+
+		$basename   = plugin_basename( Main::file() );
+		$capability = is_plugin_active_for_network( $basename ) ? 'manage_network_plugins' : 'activate_plugins';
+
+		if ( ! current_user_can( $capability ) ) {
+			wp_die( esc_html__( 'You do not have permission to deactivate this plugin.', 'plugin-name' ), 403 );
+		}
+
+		check_admin_referer( self::DELETE_ACTION );
+
+		$confirm = isset( $_POST['confirm'] ) ? sanitize_text_field( wp_unslash( (string) $_POST['confirm'] ) ) : '';
+
+		if ( $confirm === '' ) {
+			wp_die( esc_html__( 'Confirmation checkbox was not checked.', 'plugin-name' ), 400 );
+		}
+
+		$this->run_cleanup();
+
+		deactivate_plugins( $basename, false, is_network_admin() );
+
+		$redirect = add_query_arg(
+			[
+				'deactivate'        => 'true',
+				'plugin_name_wiped' => '1',
+			],
+			is_network_admin() ? network_admin_url( 'plugins.php' ) : admin_url( 'plugins.php' ),
+		);
+
+		wp_safe_redirect( $redirect );
+		exit();
+	}
+
+	/**
+	 * Switches to the main site on multisite, runs cleanup, then restores
+	 * context. Single-site installs run cleanup directly.
+	 *
+	 * @return void
+	 */
+	private function run_cleanup(): void {
+		if ( is_multisite() ) {
+			switch_to_blog( get_main_site_id() );
+			$this->cleanup_plugin_data();
+			restore_current_blog();
+			return;
+		}
+
+		$this->cleanup_plugin_data();
+	}
+
+	/**
+	 * Removes all plugin-owned data. Override or extend in derived projects
+	 * to drop custom tables, options, transients, and metadata.
+	 *
+	 * Example extensions:
+	 * - $wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}plugin_name_…" );
+	 * - delete_metadata( 'post', 0, 'plugin_name_…', '', true );
+	 * - $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_plugin_name_%'" );
+	 *
+	 * The CSV-export "backup before delete" pattern can also live alongside
+	 * this method as a third option on the confirmation screen — see the
+	 * view file for the markup hook.
+	 *
+	 * @return void
+	 */
+	protected function cleanup_plugin_data(): void {
+		delete_option( 'plugin_name_settings' );
+	}
+}

--- a/src/Admin/views/confirm-deactivate.php
+++ b/src/Admin/views/confirm-deactivate.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
  * between the two existing cards and POST to your own admin-post.php action.
  */
 
-defined( 'ABSPATH' ) || exit();
+\defined( 'ABSPATH' ) || exit();
 
 ?>
 <div class="wrap">

--- a/src/Admin/views/confirm-deactivate.php
+++ b/src/Admin/views/confirm-deactivate.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Confirmation screen for plugin-name deactivation.
+ *
+ * Variables provided by Plugin_Name\Admin\DeactivationFlow::render_confirm_page():
+ *
+ * @var string $deactivate   Standard WP deactivate URL (with nonce) for the "keep data" path.
+ * @var string $delete_url   admin.php URL the destructive form submits to.
+ * @var string $delete_nonce Nonce value for the destructive submission.
+ *
+ * Adding a third "export backup before delete" card: insert another <div class="card">
+ * between the two existing cards and POST to your own admin-post.php action.
+ */
+
+defined( 'ABSPATH' ) || exit();
+
+?>
+<div class="wrap">
+	<h1><?php esc_html_e( 'Deactivate plugin-name', 'plugin-name' ); ?></h1>
+
+	<p>
+		<?php esc_html_e( 'Choose what should happen to data captured by this plugin.', 'plugin-name' ); ?>
+	</p>
+
+	<div class="card" style="max-width: 720px;">
+		<h2><?php esc_html_e( 'Keep data (recommended)', 'plugin-name' ); ?></h2>
+		<p>
+			<?php
+			esc_html_e(
+				'Plugin settings and any captured data stay in the database. Reactivating the plugin restores everything.',
+				'plugin-name',
+			);
+			?>
+		</p>
+		<p>
+			<a href="<?php echo esc_url( $deactivate ); ?>" class="button button-primary">
+				<?php esc_html_e( 'Deactivate (keep data)', 'plugin-name' ); ?>
+			</a>
+		</p>
+	</div>
+
+	<div class="card" style="max-width: 720px; border-left: 4px solid #d63638;">
+		<h2 style="color: #d63638;">
+			<?php esc_html_e( 'Permanently delete all plugin data', 'plugin-name' ); ?>
+		</h2>
+		<p><strong><?php esc_html_e( 'This cannot be undone.', 'plugin-name' ); ?></strong></p>
+		<p>
+			<?php
+			esc_html_e(
+				'Plugin options, captured data, and transients owned by this plugin are removed before the plugin is deactivated.',
+				'plugin-name',
+			);
+			?>
+		</p>
+
+		<form method="post" action="<?php echo esc_url( $delete_url ); ?>">
+			<input type="hidden" name="action" value="<?php echo esc_attr( \Plugin_Name\Admin\DeactivationFlow::DELETE_ACTION ); ?>" />
+			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $delete_nonce ); ?>" />
+
+			<p>
+				<label>
+					<input type="checkbox" name="confirm" value="1" />
+					<?php esc_html_e( 'I understand all plugin-owned data will be permanently deleted.', 'plugin-name' ); ?>
+				</label>
+			</p>
+
+			<p>
+				<button type="submit" class="button button-secondary" style="color: #d63638; border-color: #d63638;">
+					<?php esc_html_e( 'Delete data and deactivate', 'plugin-name' ); ?>
+				</button>
+			</p>
+		</form>
+	</div>
+</div>

--- a/src/Admin/views/confirm-deactivate.php
+++ b/src/Admin/views/confirm-deactivate.php
@@ -7,9 +7,10 @@ declare(strict_types=1);
  *
  * Variables provided by Plugin_Name\Admin\DeactivationFlow::render_confirm_page():
  *
- * @var string $deactivate   Standard WP deactivate URL (with nonce) for the "keep data" path.
- * @var string $delete_url   admin.php URL the destructive form submits to.
- * @var string $delete_nonce Nonce value for the destructive submission.
+ * @var string $deactivate    Standard WP deactivate URL (with nonce) for the "keep data" path.
+ * @var string $delete_url    admin.php URL the destructive form submits to.
+ * @var string $delete_action admin_action_* handler key for the destructive submission.
+ * @var string $delete_nonce  Nonce value for the destructive submission.
  *
  * Adding a third "export backup before delete" card: insert another <div class="card">
  * between the two existing cards and POST to your own admin-post.php action.
@@ -57,7 +58,7 @@ defined( 'ABSPATH' ) || exit();
 		</p>
 
 		<form method="post" action="<?php echo esc_url( $delete_url ); ?>">
-			<input type="hidden" name="action" value="<?php echo esc_attr( \Plugin_Name\Admin\DeactivationFlow::DELETE_ACTION ); ?>" />
+			<input type="hidden" name="action" value="<?php echo esc_attr( $delete_action ); ?>" />
 			<input type="hidden" name="_wpnonce" value="<?php echo esc_attr( $delete_nonce ); ?>" />
 
 			<p>

--- a/src/Main.php
+++ b/src/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Plugin_Name;
 
+// OPT-IN: confirm-deactivate — delete this use statement if you declined the example.
 use Plugin_Name\Admin\DeactivationFlow;
 
 /**
@@ -68,6 +69,7 @@ class Main {
 	 * @return void
 	 */
 	public static function boot(): void {
+		// OPT-IN: confirm-deactivate — delete the next 3 lines if you declined the example.
 		if ( is_admin() ) {
 			( new DeactivationFlow() )->register();
 		}

--- a/src/Main.php
+++ b/src/Main.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Plugin_Name;
 
+use Plugin_Name\Admin\DeactivationFlow;
+
 /**
  * Bootstraps the plugin.
  */
@@ -66,6 +68,8 @@ class Main {
 	 * @return void
 	 */
 	public static function boot(): void {
-		// Initialize plugin functionality.
+		if ( is_admin() ) {
+			( new DeactivationFlow() )->register();
+		}
 	}
 }

--- a/tests/Unit/Admin/DeactivationFlowTest.php
+++ b/tests/Unit/Admin/DeactivationFlowTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Plugin_Name\Tests\Unit\Admin;
 
+// phpcs:disable SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses -- The Plugin_Name\* imports get rewritten by setup.sh; final alphabetical position depends on the chosen namespace.
+
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use Mockery;

--- a/tests/Unit/Admin/DeactivationFlowTest.php
+++ b/tests/Unit/Admin/DeactivationFlowTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Plugin_Name\Tests\Unit\Admin;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Plugin_Name\Admin\DeactivationFlow;
+use Plugin_Name\Main;
+use RuntimeException;
+
+/**
+ * Tests for the DeactivationFlow admin class.
+ */
+class DeactivationFlowTest extends TestCase {
+
+	/**
+	 * Sets up Brain Monkey.
+	 *
+	 * @return void
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		Functions\stubs(
+			[
+				'register_activation_hook',
+				'register_deactivation_hook',
+			],
+		);
+
+		Main::init( '/tmp/plugin.php' );
+	}
+
+	/**
+	 * Tears down Brain Monkey and superglobals.
+	 *
+	 * @return void
+	 */
+	protected function tearDown(): void {
+		$_POST    = [];
+		$_REQUEST = [];
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Verifies register() wires the expected filters and actions.
+	 *
+	 * @return void
+	 */
+	public function test_register_wires_hooks(): void {
+		Functions\stubs( [ 'plugin_basename' => 'plugin-name/plugin.php' ] );
+
+		( new DeactivationFlow() )->register();
+
+		$this->assertTrue( has_filter( 'plugin_action_links_plugin-name/plugin.php' ) > 0 );
+		$this->assertTrue( has_filter( 'network_admin_plugin_action_links_plugin-name/plugin.php' ) > 0 );
+		$this->assertTrue( has_action( 'admin_menu' ) > 0 );
+		$this->assertTrue( has_action( 'network_admin_menu' ) > 0 );
+		$this->assertTrue( has_action( 'admin_action_' . DeactivationFlow::DELETE_ACTION ) > 0 );
+	}
+
+	/**
+	 * Verifies rewrite_deactivate_link replaces the deactivate URL with the
+	 * confirmation page URL.
+	 *
+	 * @return void
+	 */
+	public function test_rewrite_deactivate_link_points_to_confirm_page(): void {
+		Functions\stubs(
+			[
+				'is_network_admin' => false,
+				'admin_url'        => static fn ( string $path ): string => 'https://example.tld/wp-admin/' . $path,
+				'add_query_arg'    => static fn ( array $args, string $url ): string => $url . '?' . \http_build_query( $args ),
+				'esc_url'          => static fn ( string $url ): string => $url,
+				'esc_html__'       => static fn ( string $text ): string => $text,
+			],
+		);
+
+		$result = ( new DeactivationFlow() )->rewrite_deactivate_link(
+			[ 'deactivate' => '<a href="original">Original</a>' ],
+		);
+
+		$this->assertStringContainsString( 'page=' . DeactivationFlow::CONFIRM_PAGE, $result['deactivate'] );
+		$this->assertStringNotContainsString( 'original', $result['deactivate'] );
+	}
+
+	/**
+	 * Verifies rewrite_deactivate_link is a no-op when no deactivate link
+	 * exists (e.g. plugin already in must-use slot).
+	 *
+	 * @return void
+	 */
+	public function test_rewrite_deactivate_link_passes_through_when_absent(): void {
+		$actions = [ 'activate' => '<a>Activate</a>' ];
+
+		$this->assertSame( $actions, ( new DeactivationFlow() )->rewrite_deactivate_link( $actions ) );
+	}
+
+	/**
+	 * Verifies the destructive handler dies when the user lacks capability.
+	 *
+	 * @return void
+	 */
+	public function test_handle_destructive_dies_on_missing_capability(): void {
+		Functions\stubs(
+			[
+				'is_user_logged_in'            => true,
+				'plugin_basename'              => 'plugin-name/plugin.php',
+				'is_plugin_active_for_network' => false,
+				'current_user_can'             => false,
+				'esc_html__'                   => static fn ( string $text ): string => $text,
+			],
+		);
+
+		Functions\expect( 'wp_die' )
+			->once()
+			->with( Mockery::type( 'string' ), 403 )
+			->andReturnUsing(
+				static function (): never {
+					throw new RuntimeException( 'wp_die_403' );
+				},
+			);
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'wp_die_403' );
+
+		( new DeactivationFlow() )->handle_destructive();
+	}
+
+	/**
+	 * Verifies the destructive handler dies when the confirm checkbox is missing.
+	 *
+	 * @return void
+	 */
+	public function test_handle_destructive_dies_on_missing_checkbox(): void {
+		Functions\stubs(
+			[
+				'is_user_logged_in'            => true,
+				'plugin_basename'              => 'plugin-name/plugin.php',
+				'is_plugin_active_for_network' => false,
+				'current_user_can'             => true,
+				'check_admin_referer'          => 1,
+				'esc_html__'                   => static fn ( string $text ): string => $text,
+			],
+		);
+
+		Functions\expect( 'wp_die' )
+			->once()
+			->with( Mockery::type( 'string' ), 400 )
+			->andReturnUsing(
+				static function (): never {
+					throw new RuntimeException( 'wp_die_400' );
+				},
+			);
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'wp_die_400' );
+
+		$_POST = [];
+
+		( new DeactivationFlow() )->handle_destructive();
+	}
+
+	/**
+	 * Verifies the destructive handler runs cleanup, deactivates, and
+	 * redirects when all gates pass.
+	 *
+	 * @return void
+	 */
+	public function test_handle_destructive_completes_full_flow(): void {
+		Functions\stubs(
+			[
+				'is_user_logged_in'            => true,
+				'plugin_basename'              => 'plugin-name/plugin.php',
+				'is_plugin_active_for_network' => false,
+				'current_user_can'             => true,
+				'check_admin_referer'          => 1,
+				'is_multisite'                 => false,
+				'is_network_admin'             => false,
+				'esc_html__'                   => static fn ( string $text ): string => $text,
+				'wp_unslash'                   => static fn ( string $value ): string => $value,
+			],
+		);
+
+		Functions\stubs(
+			[
+				'admin_url'           => static fn ( string $path ): string => 'https://example.tld/wp-admin/' . $path,
+				'add_query_arg'       => static fn ( array $args, string $url ): string => $url . '?' . \http_build_query( $args ),
+				'sanitize_text_field' => static fn ( string $value ): string => $value,
+			],
+		);
+
+		Functions\expect( 'delete_option' )
+			->once()
+			->with( 'plugin_name_settings' );
+
+		Functions\expect( 'deactivate_plugins' )
+			->once()
+			->with( 'plugin-name/plugin.php', false, false );
+
+		Functions\expect( 'wp_safe_redirect' )
+			->once()
+			->andReturnUsing(
+				static function (): never {
+					throw new RuntimeException( 'redirected' );
+				},
+			);
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'redirected' );
+
+		$_POST = [ 'confirm' => '1' ];
+
+		( new DeactivationFlow() )->handle_destructive();
+	}
+}

--- a/tests/Unit/Admin/DeactivationFlowTest.php
+++ b/tests/Unit/Admin/DeactivationFlowTest.php
@@ -221,4 +221,63 @@ class DeactivationFlowTest extends TestCase {
 
 		( new DeactivationFlow() )->handle_destructive();
 	}
+
+	/**
+	 * Verifies the network-admin path: capability is `manage_network_plugins`,
+	 * cleanup uses `delete_site_option`, deactivation is network-wide, and
+	 * the redirect target is the network plugins screen.
+	 *
+	 * @return void
+	 */
+	public function test_handle_destructive_network_admin_path(): void {
+		Functions\stubs(
+			[
+				'is_user_logged_in'            => true,
+				'plugin_basename'              => 'plugin-name/plugin.php',
+				'is_plugin_active_for_network' => true,
+				'current_user_can'             => true,
+				'check_admin_referer'          => 1,
+				'is_multisite'                 => true,
+				'is_network_admin'             => true,
+				'esc_html__'                   => static fn ( string $text ): string => $text,
+				'wp_unslash'                   => static fn ( string $value ): string => $value,
+			],
+		);
+
+		Functions\stubs(
+			[
+				'network_admin_url'   => static fn ( string $path ): string => 'https://example.tld/wp-admin/network/' . $path,
+				'add_query_arg'       => static fn ( array $args, string $url ): string => $url . '?' . \http_build_query( $args ),
+				'sanitize_text_field' => static fn ( string $value ): string => $value,
+			],
+		);
+
+		Functions\expect( 'delete_site_option' )
+			->once()
+			->with( 'plugin_name_settings' );
+
+		Functions\expect( 'deactivate_plugins' )
+			->once()
+			->with( 'plugin-name/plugin.php', false, true );
+
+		$captured_url = null;
+		Functions\expect( 'wp_safe_redirect' )
+			->once()
+			->andReturnUsing(
+				static function ( string $url ) use ( &$captured_url ): never {
+					$captured_url = $url;
+					throw new RuntimeException( 'redirected' );
+				},
+			);
+
+		$this->expectException( RuntimeException::class );
+
+		$_POST = [ 'confirm' => '1' ];
+
+		try {
+			( new DeactivationFlow() )->handle_destructive();
+		} finally {
+			$this->assertStringContainsString( 'wp-admin/network/plugins.php', (string) $captured_url );
+		}
+	}
 }

--- a/tests/Unit/MainTest.php
+++ b/tests/Unit/MainTest.php
@@ -104,6 +104,8 @@ class MainTest extends TestCase {
 	 * @return void
 	 */
 	public function test_boot(): void {
+		Functions\stubs( [ 'is_admin' => false ] );
+
 		Main::boot();
 		$this->assertTrue( true );
 	}

--- a/tests/Unit/MainTest.php
+++ b/tests/Unit/MainTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Plugin_Name\Tests\Unit;
 
+// phpcs:disable SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses.IncorrectlyOrderedUses -- The Plugin_Name\* import gets rewritten by setup.sh; final alphabetical position depends on the chosen namespace.
+
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/MainTest.php
+++ b/tests/Unit/MainTest.php
@@ -106,6 +106,7 @@ class MainTest extends TestCase {
 	 * @return void
 	 */
 	public function test_boot(): void {
+		// OPT-IN: confirm-deactivate — delete this stub if you declined the example.
 		Functions\stubs( [ 'is_admin' => false ] );
 
 		Main::boot();


### PR DESCRIPTION
## Summary

- **Add an opt-in confirm-deactivate example** under `src/Admin/DeactivationFlow.php` (plugin mode). Routes the plugin's "Deactivate" link through a confirmation screen that gates destructive cleanup behind capability, nonce, and an in-form checkbox in the same request — no persistent flag.
- **Setup script prompts** whether to include it; declined removes `src/Admin/`, `tests/Unit/Admin/`, and resets `Main.php` + `MainTest.php` to placeholder state. Theme mode unconditionally drops the example.
- **Bump `apermo/apermo-coding-standards` to `^3.0`** (breaking). Forbids short echo tags `<?= … ?>` and requires `exit;` after redirects. Existing template code audited clean for both rules.
- `apermo/reusable-workflows` v0.6.0–v0.6.2 are picked up automatically via the `@main` pin — no caller-side changes needed.

## Commits

1. `chore(deps): bump apermo-coding-standards to ^3.0`
2. `feat(admin): add opt-in confirm-deactivate example`
3. `feat(setup): prompt for confirm-deactivate example`
4. `docs: log unreleased changes for confirm-deactivate + standards bump`

## Test plan

- [x] `composer cs` clean — template state
- [x] `composer analyse` clean — template state
- [x] `composer test:unit` — 11/11 tests pass (template state)
- [x] Scratch run, plugin mode, opt-in: all checks green, 11/11 tests, DeactivationFlow wired into `Main::boot()`
- [x] Scratch run, plugin mode, opt-out: all checks green, 5/5 tests, `src/Admin/` and `tests/Unit/Admin/` removed, `Main.php` boot restored to placeholder
- [x] Scratch run, theme mode: prompt skipped, `src/Admin/` absent regardless
- [ ] Manual end-to-end in DDEV: click Deactivate → confirmation screen → submit without checkbox (400) → submit with checkbox (cleanup runs, plugin deactivates, redirect)

## Notes for reviewers

- **`Plugin_Name` import position:** the Slevomat alphabetical-sort sniff is suppressed on `tests/Unit/MainTest.php` and `tests/Unit/Admin/DeactivationFlowTest.php` because the import's final position depends on the namespace the user picks in `setup.sh` and can't be guaranteed alphabetical for all letters. Each suppression has an inline comment.
- **`DELETE_ACTION` in the view** is passed via a `$delete_action` variable rather than referenced as an FQN, so the placeholder pass doesn't need to rewrite a fully-qualified class name inside a view file.
- `cleanup_plugin_data()` ships as a documented seam — it deletes one example option (`plugin_name_settings`); derived projects extend with their own tables, options, transients.