### PR TITLE
feat(husky): add commit-msg hook — 0.10.0

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,25 @@
+# Mirrors apermo/reusable-workflows reusable-conventional-commits.yml.
+# Keep ALLOWED and MAX in lock-step with that workflow's defaults
+# (also referenced from .github/workflows/pr-validation.yml).
+
+ALLOWED='feat|fix|docs|style|refactor|test|chore|perf|ci|build'
+MAX=72
+MSG=$(head -n1 "$1")
+
+# Skip messages git itself generates.
+case "$MSG" in
+    Merge*|Revert\ \"*) exit 0 ;;
+esac
+
+if ! printf '%s' "$MSG" | grep -qE "^(${ALLOWED})(\(.+\))?!?: .{1,}$"; then
+    echo "✘ Commit subject must match: <type>[(scope)][!]: <description>" >&2
+    echo "  Allowed types: ${ALLOWED}" >&2
+    echo "  Got: $MSG" >&2
+    exit 1
+fi
+
+if [ ${#MSG} -gt $MAX ]; then
+    echo "✘ Commit subject is ${#MSG} chars, max ${MAX}." >&2
+    echo "  Got: $MSG" >&2
+    exit 1
+fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -11,7 +11,7 @@ case "$MSG" in
     Merge*|Revert\ \"*) exit 0 ;;
 esac
 
-if ! printf '%s' "$MSG" | grep -qE "^(${ALLOWED})(\(.+\))?!?: .{1,}$"; then
+if ! printf '%s\n' "$MSG" | grep -qE "^(${ALLOWED})(\(.+\))?!?: .{1,}$"; then
     echo "✘ Commit subject must match: <type>[(scope)][!]: <description>" >&2
     echo "  Allowed types: ${ALLOWED}" >&2
     echo "  Got: $MSG" >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-05-24
+
+### Added
+
+- `.husky/commit-msg` hook validating conventional-commit prefix and 72-char
+  subject length locally. Mirrors the defaults of
+  `apermo/reusable-workflows`'s `reusable-conventional-commits.yml`
+  enforced by `.github/workflows/pr-validation.yml`, so invalid commits
+  fail at `git commit` time instead of only after `git push`. Activates
+  automatically on `npm install` via the existing `prepare` script. See
+  [#42](https://github.com/apermo/template-wordpress/issues/42).
+
 ## [0.9.0] - 2026-05-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,12 @@ ddev start && ddev orchestrate   # Full WordPress environment
 
 Pre-commit hook runs PHPCS (on staged files) and PHPStan (whole project) via
 [husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged).
-It activates automatically on `npm install` via the `prepare` script.
+A `commit-msg` hook additionally enforces the conventional-commit prefix and
+72-char subject cap locally, mirroring the `pr-validation.yml` workflow (whose
+rules live in `apermo/reusable-workflows`'s
+`reusable-conventional-commits.yml`) — keep `ALLOWED`/`MAX` in
+`.husky/commit-msg` in sync with that workflow if its defaults ever change.
+Both hooks activate automatically on `npm install` via the `prepare` script.
 
 ## CI (GitHub Actions)
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ Uses [ddev-orchestrate](https://github.com/apermo/ddev-orchestrate) to download 
 ### Git Hooks
 
 The pre-commit hook (PHPCS + PHPStan) is managed by [husky](https://typicode.github.io/husky/)
-and activates automatically after `npm install`. No manual configuration required.
+and activates automatically after `npm install`. A `commit-msg` hook also
+validates the conventional-commit format locally so invalid messages are
+rejected at `git commit` time, matching the `pr-validation` CI workflow.
+No manual configuration required.
 
 ## Template Sync
 


### PR DESCRIPTION
Closes #42.

## Summary

- Adds `.husky/commit-msg` that mirrors the rules in
  `apermo/reusable-workflows`'s `reusable-conventional-commits.yml`
  (allow-list `feat|fix|docs|style|refactor|test|chore|perf|ci|build`,
  72-char subject cap, `Merge*` / `Revert "*` skipped, supports `!`
  breaking-change marker). Invalid commits now fail at `git commit` time
  instead of only after `git push` + CI rerun.
- Pure POSIX `sh`, no new dev dependencies. Activates automatically on
  `npm install` via the existing `"prepare": "husky"` script.
- README + CLAUDE.md updated with one-sentence pointers calling out the
  lock-step with `pr-validation.yml` / the reusable workflow.
- CHANGELOG.md: stamped 0.10.0 dated 2026-05-24 (new feature → minor).

## Test plan

- [x] Smoke test: 6 valid messages accepted (plain, scope, `!`,
      scope+`!`, `Merge …`, `Revert "…"`), 3 invalid rejected
      (no-prefix, unknown type `wip:`, 100-char subject).
- [x] `pr-validation` + `conventional-commits` CI jobs green on this PR.
- [x] Manual `git commit` against a junk message rejected locally on a
      throwaway working copy.