### PR TITLE
fix(hooks): bump phpstan memory limit to 1G — 0.10.1

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,6 +3,6 @@ const shellEscape = (s) => `'${s.replace(/'/g, "'\\''")}'`;
 module.exports = {
 	'*.php': (files) => [
 		`vendor/bin/phpcs --standard=phpcs.xml.dist ${files.map(shellEscape).join(' ')}`,
-		'vendor/bin/phpstan analyse --no-progress --memory-limit=512M',
+		'vendor/bin/phpstan analyse --no-progress --memory-limit=1G',
 	],
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.1] - 2026-05-24
+
+### Changed
+
+- Bump PHPStan memory limit in `.lintstagedrc.js` from 512M to 1G. The
+  previous default crashed pre-commit on derived projects with non-trivial
+  codebases (observed in `apermo/advanced-revisions`). 1G matches what
+  derived projects had been using in their pre-husky `.githooks/pre-commit`
+  scripts.
+
 ## [0.10.0] - 2026-05-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Workflow callers missing permissions (caused startup_failure)
 
+[0.10.1]: https://github.com/apermo/template-wordpress/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/apermo/template-wordpress/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/apermo/template-wordpress/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/apermo/template-wordpress/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/apermo/template-wordpress/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/apermo/template-wordpress/compare/v0.6.0...v0.6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.1] - 2026-05-24
 
-### Changed
+### Fixed
 
 - Bump PHPStan memory limit in `.lintstagedrc.js` from 512M to 1G. The
   previous default crashed pre-commit on derived projects with non-trivial


### PR DESCRIPTION
## Summary

The PHPStan memory limit in `.lintstagedrc.js` (`--memory-limit=512M`) is too tight once a derived project gets past the trivial-scaffolding stage. Confirmed crashing pre-commit hooks in [`apermo/advanced-revisions`](https://github.com/apermo/advanced-revisions/pull/23/files#diff-bf3aafc7eb27ce7d22cc1d1b9c7b58be1c84f7d62a3a55c63cd0d2cef193cee5) (which had been running 1G in its pre-husky `.githooks/pre-commit` and tripped the moment I ported the template's 512M default).

Bumping the template default to 1G means derived projects don't have to discover and fix this themselves after a `git merge template/main`. Template's own CI is unaffected — its codebase is well under either limit.

Stamped as **0.10.1** (patch — internal tooling tweak, no API change).

## Test plan

- [x] PHPCS + PHPStan still pass under the new limit (verified by the pre-commit hook on this PR's own commit).
- [ ] CI green.