### PR TITLE
fix(bootstrap): use class_exists guard, not vendor/autoload check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.2] - 2026-05-25
+
+### Fixed
+
+- Bootstrap in `plugin.php` no longer false-positives the "Please run
+  `composer install`" notice when the plugin runs inside a
+  Composer-managed parent project (Bedrock and similar). The check now
+  loads the local autoloader if present, then verifies `Main` is
+  reachable (via either the local or the parent autoloader) before
+  showing the notice. See
+  [#45](https://github.com/apermo/template-wordpress/issues/45).
+
 ## [0.10.1] - 2026-05-24
 
 ### Fixed
@@ -186,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Workflow callers missing permissions (caused startup_failure)
 
+[0.10.2]: https://github.com/apermo/template-wordpress/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/apermo/template-wordpress/compare/v0.10.0...v0.10.1
 [0.10.0]: https://github.com/apermo/template-wordpress/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/apermo/template-wordpress/compare/v0.8.0...v0.9.0

--- a/plugin.php
+++ b/plugin.php
@@ -17,7 +17,11 @@ namespace Plugin_Name;
 
 \defined( 'ABSPATH' ) || exit();
 
-if ( ! \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+if ( \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require_once __DIR__ . '/vendor/autoload.php';
+}
+
+if ( ! \class_exists( Main::class ) ) {
 	add_action(
 		'admin_notices',
 		// phpcs:ignore Universal.FunctionDeclarations.NoLongClosures.ExceedsMaximum
@@ -37,7 +41,5 @@ if ( ! \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	);
 	return;
 }
-
-require_once __DIR__ . '/vendor/autoload.php';
 
 Main::init( __FILE__ );

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,8 @@ if ( \file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 	require_once __DIR__ . '/vendor/autoload.php';
 }
 
+// Reached when neither a local vendor/autoload.php nor a parent project's
+// autoloader (Bedrock and similar) has registered the plugin's PSR-4 namespace.
 if ( ! \class_exists( Main::class ) ) {
 	add_action(
 		'admin_notices',


### PR DESCRIPTION
## Summary

- Replace the `file_exists( vendor/autoload.php )` guard in `plugin.php` with a `class_exists( Main::class )` check after an optional local-autoloader load.
- Eliminates the false-positive "Please run `composer install`" admin notice when the scaffolded plugin runs inside a Composer-managed parent project (Bedrock and similar), where the parent's autoloader already provides `Main`.
- Wording of the notice and its translation string are unchanged — only the condition that triggers it.

Closes #45.

## Test plan

- [ ] Standalone install (no parent Composer, no local `vendor/`): notice shows, plugin returns early.
- [ ] Standalone install with `composer install` run: local autoloader loads, `Main::init()` runs, no notice.
- [ ] Parent-Composer-managed install (e.g. Bedrock): parent autoloader provides `Main`, no local `vendor/` present, no notice, `Main::init()` runs.