### PR TITLE
fix: lower husky commit-subject max to 50

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -3,7 +3,7 @@
 # (also referenced from .github/workflows/pr-validation.yml).
 
 ALLOWED='feat|fix|docs|style|refactor|test|chore|perf|ci|build'
-MAX=72
+MAX=50
 MSG=$(head -n1 "$1")
 
 # Skip messages git itself generates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.4] - 2026-06-13
+
+### Fixed
+
+- Lower the local `.husky/commit-msg` subject cap from 72 to 50 so it stays
+  in lock-step with `apermo/reusable-workflows`
+  `reusable-conventional-commits.yml`, whose default `max-length` is now 50
+  (since v0.11.0). Without this, the template and every repo scaffolded from
+  it would accept 51–72-char subjects locally that CI now rejects.
+
 ## [0.10.3] - 2026-07-17
 
 ### Changed
@@ -212,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Workflow callers missing permissions (caused startup_failure)
 
+[0.10.4]: https://github.com/apermo/template-wordpress/compare/v0.10.3...v0.10.4
 [0.10.3]: https://github.com/apermo/template-wordpress/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/apermo/template-wordpress/compare/v0.10.1...v0.10.2
 [0.10.1]: https://github.com/apermo/template-wordpress/compare/v0.10.0...v0.10.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ ddev start && ddev orchestrate   # Full WordPress environment
 Pre-commit hook runs PHPCS (on staged files) and PHPStan (whole project) via
 [husky](https://typicode.github.io/husky/) and [lint-staged](https://github.com/lint-staged/lint-staged).
 A `commit-msg` hook additionally enforces the conventional-commit prefix and
-72-char subject cap locally, mirroring the `pr-validation.yml` workflow (whose
+50-char subject cap locally, mirroring the `pr-validation.yml` workflow (whose
 rules live in `apermo/reusable-workflows`'s
 `reusable-conventional-commits.yml`) — keep `ALLOWED`/`MAX` in
 `.husky/commit-msg` in sync with that workflow if its defaults ever change.


### PR DESCRIPTION
Lowers `.husky/commit-msg` `MAX` from 72 to 50 so the local hook stays in lock-step with `apermo/reusable-workflows` `reusable-conventional-commits.yml`, whose default `max-length` is now 50 (apermo/reusable-workflows#38, shipped in v0.11.0).

Without this, the template (and every repo scaffolded from it) would accept 51–72-char subjects locally that CI now rejects. Follow-up to apermo/reusable-workflows#49.